### PR TITLE
Ignore proxy "Connection established" headers

### DIFF
--- a/request.el
+++ b/request.el
@@ -1004,6 +1004,11 @@ See \"set-cookie-av\" in http://www.ietf.org/rfc/rfc2965.txt")
       ;; FIXME: Does this make sense?  Is it possible to have multiple 100?
       (request--consume-100-continue))))
 
+(defun request--consume-200-connection-established ()
+  "Remove \"HTTP/* 200 Connection established\" header at the point."
+  (when (looking-at-p "HTTP/1\\.0 200 Connection established")
+    (delete-region (point) (progn (request--goto-next-body) (point)))))
+
 (defun request--curl-preprocess ()
   "Pre-process current buffer before showing it to user."
   (let (history)
@@ -1011,6 +1016,7 @@ See \"set-cookie-av\" in http://www.ietf.org/rfc/rfc2965.txt")
         (request--curl-read-and-delete-tail-info)
       (goto-char (point-min))
       (request--consume-100-continue)
+      (request--consume-200-connection-established)
       (when (> num-redirects 0)
         (loop with case-fold-search = t
               repeat num-redirects

--- a/tests/test-request.el
+++ b/tests/test-request.el
@@ -668,6 +668,38 @@ RESPONSE-BODY"))
                            :history nil
                            :version "1.1" :code 200))))))
 
+(ert-deftest request--curl-preprocess/200-proxy-connection-established ()
+  (with-temp-buffer
+    (erase-buffer)
+    (insert "\
+HTTP/1.0 200 Connection established\r
+\r
+HTTP/1.1 200 OK\r
+Content-Type: application/json\r
+Date: Wed, 19 Dec 2012 16:51:53 GMT\r
+Server: gunicorn/0.13.4\r
+Content-Length: 492\r
+Connection: keep-alive\r
+\r
+RESPONSE-BODY")
+    (insert "\n(:num-redirects 0 :url-effective \"DUMMY-URL\")")
+    (let ((info (request--curl-preprocess)))
+      (should (equal (buffer-string)
+                     "\
+HTTP/1.1 200 OK\r
+Content-Type: application/json\r
+Date: Wed, 19 Dec 2012 16:51:53 GMT\r
+Server: gunicorn/0.13.4\r
+Content-Length: 492\r
+Connection: keep-alive\r
+\r
+RESPONSE-BODY"))
+      (should (equal info
+                     (list :num-redirects 0
+                           :url-effective "DUMMY-URL"
+                           :history nil
+                           :version "1.1" :code 200))))))
+
 (ert-deftest request--curl-absolutify-redirects/simple ()
   (should (equal (request--curl-absolutify-redirects
                   "http://localhost"


### PR DESCRIPTION
The Squid proxy adds an extra header "HTTP/1.0 200 Connection established"
which libcurl (since 7.11.1) passes through unmodified.

Reference: http://curl.haxx.se/mail/lib-2005-10/0024.html

This replaces pull request #11.
