### PR TITLE
Default to UTF-8 for encoding and decoding

### DIFF
--- a/request.el
+++ b/request.el
@@ -971,6 +971,7 @@ removed from the buffer before it is shown to the parser function.
     (process-put proc :request-response response)
     (set-process-query-on-exit-flag proc nil)
     (set-process-sentinel proc #'request--curl-callback)
+    (set-process-coding-system proc 'utf-8 'utf-8)
     (when data
       (process-send-string proc data)
       (process-send-eof proc))))


### PR DESCRIPTION
I just had a really confusing encoding bug which led me back to the encoding used to comunicate with cURL..  I'm not sure this is the best solution, but it should make most things work.