### PR TITLE
 Use cl-lib instead of the old prefix-less CL package

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,4 @@
+;;; Directory Local Variables
+;;; For more information see (info "(emacs) Directory Variables")
+
+((emacs-lisp-mode (indent-tabs-mode . nil)))


### PR DESCRIPTION
`cl-lib' is available for older Emacsen, see http://elpa.gnu.org/packages/cl-lib.html.