### PR TITLE
Specify curl process encoding

### DIFF
--- a/request.el
+++ b/request.el
@@ -969,6 +969,7 @@ removed from the buffer before it is shown to the parser function.
     (request-log 'debug "Run: %s" (mapconcat 'identity command " "))
     (setf (request-response--buffer response) buffer)
     (process-put proc :request-response response)
+    (set-process-coding-system proc 'binary 'binary)
     (set-process-query-on-exit-flag proc nil)
     (set-process-sentinel proc #'request--curl-callback)
     (when data


### PR DESCRIPTION
`request--consume-100-continue` may fail under the following conditions.

1. curl posts more than 1024 byte data. (it will add header `Expect: 100-continue`)
  - http://d.hatena.ne.jp/tokuhy/20091202/1259766797
2. curl process-coding-system is `*-dos`.

Error example:

```emacs-lisp
(let* ((byte 1025)
       (request-backend 'curl)
       (request-message-level 'debug)
       (default-process-coding-system '(undecided-dos . undecided-dos)))
  (request "http://httpbin.org/post"
           :type "POST"
           :data (with-output-to-string
                   (dotimes (_ byte)
                     (princ ".")))
           :success #'ignore))
```

Message log:

```
;;; *Message* 
REQUEST [debug] REQUEST
REQUEST [debug] Run: curl --silent --include --location --compressed --cookie curl-cookie-jar --cookie-jar curl-cookie-jar --write-out \n(:num-redirects %{num_redirects} :url-effective "%{url_effective}") --data-binary @- --request POST http://httpbin.org/post
...
REQUEST [debug] REQUEST-RESPONSE--CANCEL-TIMER
REQUEST [debug] -CLEAN-HEADER
REQUEST [debug] -CUT-HEADER
REQUEST [debug] error-thrown = (search-failed "^\r\n")
REQUEST [debug] data = nil
REQUEST [debug] symbol-status = error
REQUEST [debug] Executing error callback.
REQUEST [error] Error (error) while connecting to http://httpbin.org/post.
```