### PR TITLE
Correct arguments in error callback

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,7 +85,7 @@ Rich callback dispatch (like `jQuery.ajax`)::
                     (insert data)
                     (pop-to-buffer (current-buffer))))))
    :error
-   (function* (lambda (&key error-thrown &allow-other-keys&rest _)
+   (function* (lambda (&rest args &key error-thrown &allow-other-keys)
                 (message "Got error: %S" error-thrown)))
    :complete (lambda (&rest _) (message "Finished!"))
    :status-code '((400 . (lambda (&rest _) (message "Got 400.")))


### PR DESCRIPTION
There is no '&allow-other-keys&rest' keyword and it is treated as
normal argument. And '&rest' keyword should be declared before '&key'
keyword.