### PR TITLE
Try to parse response also when server errored

### DIFF
--- a/request.el
+++ b/request.el
@@ -645,10 +645,12 @@ then kill the current buffer."
 
     ;; Parse response body
     (request-log 'debug "error-thrown = %S" error-thrown)
-    (unless error-thrown
-      (condition-case err
-          (request--parse-data response parser)
-        (error
+    (condition-case err
+        (request--parse-data response parser)
+      (error
+       ;; If there was already an error (e.g. server timeout) do not set the
+       ;; status to `parse-error'.
+       (unless error-thrown
          (setq symbol-status 'parse-error)
          (setq error-thrown err)
          (request-log 'error "Error from parser %S: %S" parser err))))


### PR DESCRIPTION
When the server errors, there might still something be to parse from the response. This patch removes a check that prevented to parse the response on server error.

Check also the comment a few lines above the change, which indicates that response should be read even if server errors.