### PR TITLE
Ignore errors from request--parse-response-at-point

### DIFF
--- a/request.el
+++ b/request.el
@@ -841,7 +841,7 @@ associated process is exited."
       (with-current-buffer buffer
         (goto-char (point-min))
         (cl-destructuring-bind (&key version code)
-            (request--parse-response-at-point)
+            (ignore-errors (request--parse-response-at-point))
           (setf (request-response-status-code response) code)))
       ;; Parse response body, etc.
       (apply #'request--callback buffer settings)))


### PR DESCRIPTION
It can happen that the response buffer is empty and in that case the function `request--parse-response-at-point` errors with `search failed..`. Wrap the function with `ignore-errors` to return nil in case of error.