### PR TITLE
Drop older emacs support for maintenance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 sudo: false
 env:
-  - EVM_EMACS=emacs-24.3-travis
   - EVM_EMACS=emacs-24.4-travis
   - EVM_EMACS=emacs-24.5-travis
+  - EVM_EMACS=emacs-25.1-travis
 before_install:
   - pip install -q flask tornado
   - curl -fsSkL https://gist.github.com/rejeep/ebcd57c3af83b049833b/raw > x.sh && source ./x.sh

--- a/README.rst
+++ b/README.rst
@@ -177,11 +177,9 @@ Supported Emacs versions:
  Emacs version          Does request.el work?      Tested on Travis CI
                                                    |build-status|
 ====================== ========================== =====================
+ GNU Emacs 25.1         yes (as of this writing)   yes
  GNU Emacs 24.5         yes (as of this writing)   yes
  GNU Emacs 24.4         yes (as of this writing)   yes
- GNU Emacs 24.3         yes (as of this writing)   yes
- GNU Emacs 24.2         yes                        no
- GNU Emacs 24.1         yes                        no
 ====================== ========================== =====================
 
 
@@ -193,29 +191,6 @@ Supported backends:
  url.el     Included in Emacs
  curl       Reliable             ✔               ✔                         ✔
 ========== ==================== ================ ========================= =============
-
-
-Monkey patches for url.el
-=========================
-
-Patches for following bugs are applied when request.el is loaded.
-If the patch is not required for the Emacs version you are using, it
-will not be applied.
-
-- `#12374 - 24.1.50;
-  Incorrect redirect in url-retrieve when URL contains port number -
-  GNU bug report logs
-  <http://debbugs.gnu.org/cgi/bugreport.cgi?bug=12374>`_
-
-  (patch: `PATCH Fix bug 12374 treat port number when expanding URL
-  <http://article.gmane.org/gmane.emacs.devel/155698>`_)
-
-- `#11469 - 24.1.50; url-retrieve with PUT method fails every two
-  times - GNU bug report logs
-  <http://debbugs.gnu.org/cgi/bugreport.cgi?bug=11469>`_
-
-  (patch: `PATCH Fix bug 11469 propagate url request vars properly
-  <http://article.gmane.org/gmane.emacs.devel/155697>`_)
 
 
 Related projects


### PR DESCRIPTION
And remove workaround code for older Emacs. All of them are applied on
Emacs 24.4 or higher versions.