### PR TITLE
Use file-remote-p to generate remote temp file names

### DIFF
--- a/request.el
+++ b/request.el
@@ -960,16 +960,8 @@ Currently it is used only for testing.")
 
 (defun request--make-temp-file ()
   "Create a temporary file."
-  (if (file-remote-p default-directory)
-      (let ((tramp-temp-name-prefix request-temp-prefix)
-            (vec (tramp-dissect-file-name default-directory)))
-        (tramp-make-tramp-file-name
-         (tramp-file-name-method vec)
-         (tramp-file-name-user vec)
-         (tramp-file-name-host vec)
-         (tramp-make-tramp-temp-file vec)
-         (tramp-file-name-hop vec)))
-    (make-temp-file request-temp-prefix)))
+  (make-temp-file
+   (concat (file-remote-p default-directory) request-temp-prefix)))
 
 (defun request--curl-normalize-files (files)
   "Change FILES into a list of (NAME FILENAME PATH MIME-TYPE).
@@ -1020,15 +1012,7 @@ removed from the buffer before it is shown to the parser function.
   (let* (;; Use pipe instead of pty.  Otherwise, curl process hangs.
          (process-connection-type nil)
          ;; Avoid starting program in non-existing directory.
-         (home-directory (if (file-remote-p default-directory)
-                             (let ((vec (tramp-dissect-file-name default-directory)))
-                               (tramp-make-tramp-file-name
-                                (tramp-file-name-method vec)
-                                (tramp-file-name-user vec)
-                                (tramp-file-name-host vec)
-                                "~/"
-                                (tramp-file-name-hop vec)))
-                           "~/"))
+         (home-directory (concat (file-remote-p default-directory) "~/"))
          (default-directory (expand-file-name home-directory))
          (buffer (generate-new-buffer " *request curl*"))
          (command (cl-destructuring-bind


### PR DESCRIPTION
As of Emacs's dca22e86e0 (Introduce a defstruct `tramp-file-name' as central
data structure, 2017-05-24), tramp-make-tramp-file-name takes two more
positional arguments. Use `file-remote-p` to generate temp files with remote
identifier components instead of adding version dependent function calls.

See abingham/emacs-ycmd#439 and magit/with-editor#29 for stack traces.