### PR TITLE
Enable to set coding system for encoding/decoding

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -145,6 +145,21 @@ PUT JSON data:
              (lambda (&key data &allow-other-keys)
                (message "I sent: %S" (assoc-default 'json data)))))
 
+PUT JSON data including non-ascii strings:
+
+.. code:: emacs-lisp
+
+  (setq request-conding-system 'utf-8)
+  (request
+   "http://httpbin.org/put"
+   :type "PUT"
+   :data (json-encode '(("key" . "値1") ("key2" . "値2")))
+   :headers '(("Content-Type" . "application/json"))
+   :parser 'json-read
+   :success (cl-function
+             (lambda (&key data &allow-other-keys)
+               (message "I sent: %S" (assoc-default 'json data)))))
+
 Another PUT JSON example (nested JSON using alist structure, how to represent a boolean & how to selectively evaluate lisp):
 
 .. code:: emacs-lisp

--- a/README.rst
+++ b/README.rst
@@ -149,7 +149,7 @@ PUT JSON data including non-ascii strings:
 
 .. code:: emacs-lisp
 
-  (setq request-conding-system 'utf-8)
+  (setq request-coding-system 'utf-8)
   (request
    "http://httpbin.org/put"
    :type "PUT"

--- a/request.el
+++ b/request.el
@@ -63,7 +63,7 @@
   "Directory to store data related to request.el."
   :type 'directory)
 
-(defcustom request-conding-system 'binary
+(defcustom request-coding-system 'binary
   "coding-system for request."
   :type 'symbol)
 
@@ -922,10 +922,10 @@ Currently it is used only for testing.")
      (let ((tempfile (request--make-temp-file)))
        (push tempfile (request-response--tempfiles response))
        (let ((file-coding-system-alist nil)
-             (coding-system-for-write request-conding-system))
+             (coding-system-for-write request-coding-system))
          (with-temp-file tempfile
-           (setq buffer-file-coding-system request-conding-system)
-           (if (eq request-conding-system 'binary)
+           (setq buffer-file-coding-system request-coding-system)
+           (if (eq request-coding-system 'binary)
                (set-buffer-multibyte nil))
            (insert data)))
        (list "--data-binary" (concat  "@" (request-untrampify-filename tempfile)))))
@@ -1046,7 +1046,7 @@ removed from the buffer before it is shown to the parser function.
     (request-log 'debug "Run: %s" (mapconcat 'identity command " "))
     (setf (request-response--buffer response) buffer)
     (process-put proc :request-response response)
-    (set-process-coding-system proc request-conding-system request-conding-system)
+    (set-process-coding-system proc request-coding-system request-coding-system)
     (set-process-query-on-exit-flag proc nil)
     (set-process-sentinel proc #'request--curl-callback)))
 

--- a/request.el
+++ b/request.el
@@ -63,6 +63,10 @@
   "Directory to store data related to request.el."
   :type 'directory)
 
+(defcustom request-conding-system 'binary
+  "coding-system for request."
+  :type 'symbol)
+
 (defcustom request-curl "curl"
   "Executable for curl command."
   :type 'string)
@@ -918,10 +922,11 @@ Currently it is used only for testing.")
      (let ((tempfile (request--make-temp-file)))
        (push tempfile (request-response--tempfiles response))
        (let ((file-coding-system-alist nil)
-             (coding-system-for-write 'binary))
+             (coding-system-for-write request-conding-system))
          (with-temp-file tempfile
-           (setq buffer-file-coding-system 'binary)
-           (set-buffer-multibyte nil)
+           (setq buffer-file-coding-system request-conding-system)
+           (if (eq request-conding-system 'binary)
+               (set-buffer-multibyte nil))
            (insert data)))
        (list "--data-binary" (concat  "@" (request-untrampify-filename tempfile)))))
    (when type (list "--request" type))
@@ -1041,7 +1046,7 @@ removed from the buffer before it is shown to the parser function.
     (request-log 'debug "Run: %s" (mapconcat 'identity command " "))
     (setf (request-response--buffer response) buffer)
     (process-put proc :request-response response)
-    (set-process-coding-system proc 'binary 'binary)
+    (set-process-coding-system proc request-conding-system request-conding-system)
     (set-process-query-on-exit-flag proc nil)
     (set-process-sentinel proc #'request--curl-callback)))
 

--- a/tests/test-request.el
+++ b/tests/test-request.el
@@ -212,6 +212,18 @@ See also:
     (should (equal (assoc-default "method" data) "POST"))
     (should (equal (assoc-default "form"   data) '(("鍵" . "値"))))))
 
+(request-deftest request-simple-post-json ()
+  (request-testing-with-response-slots
+      (request-testing-sync "report/some-path"
+                            :type "POST" :data "{\"a\": 1, \"b\": 2, \"c\": 3}"
+                            :headers '(("Content-Type" . "application/json"))
+                            :parser 'json-read)
+    (should (equal status-code 200))
+    (should (equal (assoc-default 'path data) "some-path"))
+    (should (equal (assoc-default 'method data) "POST"))
+    (should (equal (request-testing-sort-alist (assoc-default 'json data))
+                   '((a . 1) (b . 2) (c . 3))))))
+
 (request-deftest request-post-files/simple-buffer ()
   :backends (curl)
   (with-current-buffer (get-buffer-create " *request-test-temp*")
@@ -358,6 +370,20 @@ To check that, run test with:
     (should (equal (assoc-default 'method data) "PUT"))
     (should (equal (request-testing-sort-alist (assoc-default 'json data))
                    '((a . 1) (b . 2) (c . 3))))))
+
+(request-deftest request-simple-post-multibyte-json ()
+   :backends (curl)
+   (setq request-conding-system 'utf-8)
+   (request-testing-with-response-slots
+      (request-testing-sync "report/some-path"
+                            :type "POST" :data "{\"鍵\": \"値\"}"
+                            :headers '(("Content-Type" . "application/json"))
+                            :parser 'json-read)
+    (should (equal status-code 200))
+    (should (equal (assoc-default 'path data) "some-path"))
+    (should (equal (assoc-default 'method data) "POST"))
+    (should (equal (request-testing-sort-alist (assoc-default 'json data))
+                   '((鍵 . "値"))))))
 
 
 ;;; DELETE

--- a/tests/test-request.el
+++ b/tests/test-request.el
@@ -373,7 +373,7 @@ To check that, run test with:
 
 (request-deftest request-simple-post-multibyte-json ()
    :backends (curl)
-   (setq request-conding-system 'utf-8)
+   (setq request-coding-system 'utf-8)
    (request-testing-with-response-slots
       (request-testing-sync "report/some-path"
                             :type "POST" :data "{\"鍵\": \"値\"}"


### PR DESCRIPTION
Non-ascii strings in JSON data would be unicoded when POSTing curl with JSON data because
buffer-file-coding-system in data buffer is 'binary.

But to change this code is not good for web page whose encoding is other encoding, so
set encode in variable request-conding-system.

Example:
```lisp
(setq request-conding-system 'utf-8)
(request
 "http://httpbin.org/put"
 :type "PUT"
 :data (json-encode '(("key" . "値1") ("key2" . "値2")))
 :headers '(("Content-Type" . "application/json"))
 :parser 'json-read
 :success (cl-function
           (lambda (&key data &allow-other-keys)
             (message "I sent: %S" (assoc-default 'json data)))))
```