### PR TITLE
Update Travis CI build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,12 @@ env:
   - EVM_EMACS=emacs-24.4-travis
   - EVM_EMACS=emacs-24.5-travis
   - EVM_EMACS=emacs-25.1-travis
+  - EVM_EMACS=emacs-25.2-travis
+  - EVM_EMACS=emacs-25.3-travis
+  - EVM_EMACS=emacs-26-pretest-travis
+  - EVM_EMACS=emacs-git-snapshot-travis
+allow_failures:
+  - EVM_EMACS=emacs-git-snapshot-travis
 before_install:
   - pip install -q flask tornado
   - curl -fsSkL https://gist.github.com/rejeep/ebcd57c3af83b049833b/raw > x.sh && source ./x.sh


### PR DESCRIPTION
This pull request updates the build matrix in .travis.yml to include more recent Emacs releases.

~~Along the way I also had to introduce an additional set of configuration to work around what seems to be a malformed TLS certificate[1] on https://elpa.gnu.org. I first ran into this issue in the clojure-emacs/cider project[2] and used the same workaround in that project.~~

~~[1] https://lists.gnu.org/archive/html/emacs-devel/2018-02/msg00142.html~~
~~[2] https://github.com/clojure-emacs/cider/issues/2129~~
