### PR TITLE
(github pages) Replace references to function* and defun* with cl-lib versions

### DIFF
--- a/_sources/index.txt
+++ b/_sources/index.txt
@@ -42,7 +42,7 @@ GET::
    "http://httpbin.org/get"
    :params '(("key" . "value") ("key2" . "value2"))
    :parser 'json-read
-   :success (function*
+   :success (cl-function
              (lambda (&key data &allow-other-keys)
                (message "I sent: %S" (assoc-default 'args data)))))
 
@@ -54,7 +54,7 @@ POST::
    :data '(("key" . "value") ("key2" . "value2"))
    ;; :data "key=value&key2=value2"  ; this is equivalent
    :parser 'json-read
-   :success (function*
+   :success (cl-function
              (lambda (&key data &allow-other-keys)
                (message "I sent: %S" (assoc-default 'form data)))))
 
@@ -66,7 +66,7 @@ POST file (**WARNING**: it will send the contents of the current buffer!)::
    :files `(("current buffer" . ,(current-buffer))
             ("data" . ("data.csv" :data "1,2,3\n4,5,6\n")))
    :parser 'json-read
-   :success (function*
+   :success (cl-function
              (lambda (&key data &allow-other-keys)
                (message "I sent: %S" (assoc-default 'files data)))))
 
@@ -78,14 +78,14 @@ Rich callback dispatch (like `jQuery.ajax`)::
    ;; "http://httpbin.org/status/400"  ; you will see "Got 400."
    :parser 'buffer-string
    :success
-   (function* (lambda (&key data &allow-other-keys)
+   (cl-function (lambda (&key data &allow-other-keys)
                 (when data
                   (with-current-buffer (get-buffer-create "*request demo*")
                     (erase-buffer)
                     (insert data)
                     (pop-to-buffer (current-buffer))))))
    :error
-   (function* (lambda (&key error-thrown &allow-other-keys&rest _)
+   (cl-function (lambda (&key error-thrown &allow-other-keys&rest _)
                 (message "Got error: %S" error-thrown)))
    :complete (lambda (&rest _) (message "Finished!"))
    :status-code '((400 . (lambda (&rest _) (message "Got 400.")))
@@ -97,7 +97,7 @@ Flexible PARSER option::
    "https://github.com/tkf/emacs-request/commits/master.atom"
    ;; Parse XML in response body:
    :parser (lambda () (libxml-parse-xml-region (point) (point-max)))
-   :success (function*
+   :success (cl-function
              (lambda (&key data &allow-other-keys)
                ;; Just don't look at this function....
                (let ((get (lambda (node &rest names)
@@ -119,7 +119,7 @@ PUT JSON data::
    :data (json-encode '(("key" . "value") ("key2" . "value2")))
    :headers '(("Content-Type" . "application/json"))
    :parser 'json-read
-   :success (function*
+   :success (cl-function
              (lambda (&key data &allow-other-keys)
                (message "I sent: %S" (assoc-default 'json data)))))
 

--- a/index.html
+++ b/index.html
@@ -82,8 +82,8 @@ See <a class="reference internal" href="#monkey-patches-for-url-el">monkey patch
  <span class="s">&quot;http://httpbin.org/get&quot;</span>
  <span class="ss">:params</span> <span class="o">&#39;</span><span class="p">((</span><span class="s">&quot;key&quot;</span> <span class="o">.</span> <span class="s">&quot;value&quot;</span><span class="p">)</span> <span class="p">(</span><span class="s">&quot;key2&quot;</span> <span class="o">.</span> <span class="s">&quot;value2&quot;</span><span class="p">))</span>
  <span class="ss">:parser</span> <span class="ss">&#39;json-read</span>
- <span class="ss">:success</span> <span class="p">(</span><span class="nv">function*</span>
-           <span class="p">(</span><span class="k">lambda</span> <span class="p">(</span><span class="k">&amp;key</span> <span class="nv">data</span> <span class="k">&amp;allow-other-keys</span><span class="p">)</span>
+ <span class="ss">:success</span> <span class="p">(</span><span class="nv">cl-function</span>
+ <span class="p">(</span><span class="k">lambda</span> <span class="p">(</span><span class="k">&amp;key</span> <span class="nv">data</span> <span class="k">&amp;allow-other-keys</span><span class="p">)</span>
              <span class="p">(</span><span class="nv">message</span> <span class="s">&quot;I sent: %S&quot;</span> <span class="p">(</span><span class="nv">assoc-default</span> <span class="ss">&#39;args</span> <span class="nv">data</span><span class="p">)))))</span>
 </pre></div>
 </div>
@@ -94,8 +94,8 @@ See <a class="reference internal" href="#monkey-patches-for-url-el">monkey patch
  <span class="ss">:data</span> <span class="o">&#39;</span><span class="p">((</span><span class="s">&quot;key&quot;</span> <span class="o">.</span> <span class="s">&quot;value&quot;</span><span class="p">)</span> <span class="p">(</span><span class="s">&quot;key2&quot;</span> <span class="o">.</span> <span class="s">&quot;value2&quot;</span><span class="p">))</span>
  <span class="c1">;; :data &quot;key=value&amp;key2=value2&quot;  ; this is equivalent</span>
  <span class="ss">:parser</span> <span class="ss">&#39;json-read</span>
- <span class="ss">:success</span> <span class="p">(</span><span class="nv">function*</span>
-           <span class="p">(</span><span class="k">lambda</span> <span class="p">(</span><span class="k">&amp;key</span> <span class="nv">data</span> <span class="k">&amp;allow-other-keys</span><span class="p">)</span>
+ <span class="ss">:success</span> <span class="p">(</span><span class="nv">cl-function</span>
+ <span class="p">(</span><span class="k">lambda</span> <span class="p">(</span><span class="k">&amp;key</span> <span class="nv">data</span> <span class="k">&amp;allow-other-keys</span><span class="p">)</span>
              <span class="p">(</span><span class="nv">message</span> <span class="s">&quot;I sent: %S&quot;</span> <span class="p">(</span><span class="nv">assoc-default</span> <span class="ss">&#39;form</span> <span class="nv">data</span><span class="p">)))))</span>
 </pre></div>
 </div>
@@ -106,8 +106,8 @@ See <a class="reference internal" href="#monkey-patches-for-url-el">monkey patch
  <span class="ss">:files</span> <span class="o">`</span><span class="p">((</span><span class="s">&quot;current buffer&quot;</span> <span class="o">.</span> <span class="o">,</span><span class="p">(</span><span class="nv">current-buffer</span><span class="p">))</span>
           <span class="p">(</span><span class="s">&quot;data&quot;</span> <span class="o">.</span> <span class="p">(</span><span class="s">&quot;data.csv&quot;</span> <span class="ss">:data</span> <span class="s">&quot;1,2,3\n4,5,6\n&quot;</span><span class="p">)))</span>
  <span class="ss">:parser</span> <span class="ss">&#39;json-read</span>
- <span class="ss">:success</span> <span class="p">(</span><span class="nv">function*</span>
-           <span class="p">(</span><span class="k">lambda</span> <span class="p">(</span><span class="k">&amp;key</span> <span class="nv">data</span> <span class="k">&amp;allow-other-keys</span><span class="p">)</span>
+ <span class="ss">:success</span> <span class="p">(</span><span class="nv">cl-function</span>
+ <span class="p">(</span><span class="k">lambda</span> <span class="p">(</span><span class="k">&amp;key</span> <span class="nv">data</span> <span class="k">&amp;allow-other-keys</span><span class="p">)</span>
              <span class="p">(</span><span class="nv">message</span> <span class="s">&quot;I sent: %S&quot;</span> <span class="p">(</span><span class="nv">assoc-default</span> <span class="ss">&#39;files</span> <span class="nv">data</span><span class="p">)))))</span>
 </pre></div>
 </div>
@@ -118,15 +118,15 @@ See <a class="reference internal" href="#monkey-patches-for-url-el">monkey patch
  <span class="c1">;; &quot;http://httpbin.org/status/400&quot;  ; you will see &quot;Got 400.&quot;</span>
  <span class="ss">:parser</span> <span class="ss">&#39;buffer-string</span>
  <span class="ss">:success</span>
- <span class="p">(</span><span class="nv">function*</span> <span class="p">(</span><span class="k">lambda</span> <span class="p">(</span><span class="k">&amp;key</span> <span class="nv">data</span> <span class="k">&amp;allow-other-keys</span><span class="p">)</span>
-              <span class="p">(</span><span class="nb">when</span> <span class="nv">data</span>
+ <span class="p">(</span><span class="nv">cl-function</span> <span class="p">(</span><span class="k">lambda</span> <span class="p">(</span><span class="k">&amp;key</span> <span class="nv">data</span> <span class="k">&amp;allow-other-keys</span><span class="p">)</span>
+ <span class="p">(</span><span class="nb">when</span> <span class="nv">data</span>
                 <span class="p">(</span><span class="nv">with-current-buffer</span> <span class="p">(</span><span class="nv">get-buffer-create</span> <span class="s">&quot;*request demo*&quot;</span><span class="p">)</span>
                   <span class="p">(</span><span class="nv">erase-buffer</span><span class="p">)</span>
                   <span class="p">(</span><span class="nv">insert</span> <span class="nv">data</span><span class="p">)</span>
                   <span class="p">(</span><span class="nv">pop-to-buffer</span> <span class="p">(</span><span class="nv">current-buffer</span><span class="p">))))))</span>
  <span class="ss">:error</span>
- <span class="p">(</span><span class="nv">function*</span> <span class="p">(</span><span class="k">lambda</span> <span class="p">(</span><span class="k">&amp;key</span> <span class="nv">error-thrown</span> <span class="nv">&amp;allow-other-keys&amp;rest</span> <span class="nv">_</span><span class="p">)</span>
-              <span class="p">(</span><span class="nv">message</span> <span class="s">&quot;Got error: %S&quot;</span> <span class="nv">error-thrown</span><span class="p">)))</span>
+ <span class="p">(</span><span class="nv">cl-function</span> <span class="p">(</span><span class="k">lambda</span> <span class="p">(</span><span class="k">&amp;key</span> <span class="nv">error-thrown</span> <span class="nv">&amp;allow-other-keys&amp;rest</span> <span class="nv">_</span><span class="p">)</span>
+ <span class="p">(</span><span class="nv">message</span> <span class="s">&quot;Got error: %S&quot;</span> <span class="nv">error-thrown</span><span class="p">)))</span>
  <span class="ss">:complete</span> <span class="p">(</span><span class="k">lambda</span> <span class="p">(</span><span class="k">&amp;rest</span> <span class="nv">_</span><span class="p">)</span> <span class="p">(</span><span class="nv">message</span> <span class="s">&quot;Finished!&quot;</span><span class="p">))</span>
  <span class="ss">:status-code</span> <span class="o">&#39;</span><span class="p">((</span><span class="mi">400</span> <span class="o">.</span> <span class="p">(</span><span class="k">lambda</span> <span class="p">(</span><span class="k">&amp;rest</span> <span class="nv">_</span><span class="p">)</span> <span class="p">(</span><span class="nv">message</span> <span class="s">&quot;Got 400.&quot;</span><span class="p">)))</span>
                 <span class="p">(</span><span class="mi">418</span> <span class="o">.</span> <span class="p">(</span><span class="k">lambda</span> <span class="p">(</span><span class="k">&amp;rest</span> <span class="nv">_</span><span class="p">)</span> <span class="p">(</span><span class="nv">message</span> <span class="s">&quot;Got 418.&quot;</span><span class="p">)))))</span>
@@ -137,8 +137,8 @@ See <a class="reference internal" href="#monkey-patches-for-url-el">monkey patch
  <span class="s">&quot;https://github.com/tkf/emacs-request/commits/master.atom&quot;</span>
  <span class="c1">;; Parse XML in response body:</span>
  <span class="ss">:parser</span> <span class="p">(</span><span class="k">lambda</span> <span class="p">()</span> <span class="p">(</span><span class="nv">libxml-parse-xml-region</span> <span class="p">(</span><span class="nv">point</span><span class="p">)</span> <span class="p">(</span><span class="nv">point-max</span><span class="p">)))</span>
- <span class="ss">:success</span> <span class="p">(</span><span class="nv">function*</span>
-           <span class="p">(</span><span class="k">lambda</span> <span class="p">(</span><span class="k">&amp;key</span> <span class="nv">data</span> <span class="k">&amp;allow-other-keys</span><span class="p">)</span>
+ <span class="ss">:success</span> <span class="p">(</span><span class="nv">cl-function</span>
+ <span class="p">(</span><span class="k">lambda</span> <span class="p">(</span><span class="k">&amp;key</span> <span class="nv">data</span> <span class="k">&amp;allow-other-keys</span><span class="p">)</span>
              <span class="c1">;; Just don&#39;t look at this function....</span>
              <span class="p">(</span><span class="k">let</span> <span class="p">((</span><span class="nb">get</span> <span class="p">(</span><span class="k">lambda</span> <span class="p">(</span><span class="nv">node</span> <span class="k">&amp;rest</span> <span class="nv">names</span><span class="p">)</span>
                           <span class="p">(</span><span class="k">if</span> <span class="nv">names</span>
@@ -159,8 +159,8 @@ See <a class="reference internal" href="#monkey-patches-for-url-el">monkey patch
  <span class="ss">:data</span> <span class="p">(</span><span class="nv">json-encode</span> <span class="o">&#39;</span><span class="p">((</span><span class="s">&quot;key&quot;</span> <span class="o">.</span> <span class="s">&quot;value&quot;</span><span class="p">)</span> <span class="p">(</span><span class="s">&quot;key2&quot;</span> <span class="o">.</span> <span class="s">&quot;value2&quot;</span><span class="p">)))</span>
  <span class="ss">:headers</span> <span class="o">&#39;</span><span class="p">((</span><span class="s">&quot;Content-Type&quot;</span> <span class="o">.</span> <span class="s">&quot;application/json&quot;</span><span class="p">))</span>
  <span class="ss">:parser</span> <span class="ss">&#39;json-read</span>
- <span class="ss">:success</span> <span class="p">(</span><span class="nv">function*</span>
-           <span class="p">(</span><span class="k">lambda</span> <span class="p">(</span><span class="k">&amp;key</span> <span class="nv">data</span> <span class="k">&amp;allow-other-keys</span><span class="p">)</span>
+ <span class="ss">:success</span> <span class="p">(</span><span class="nv">cl-function</span>
+ <span class="p">(</span><span class="k">lambda</span> <span class="p">(</span><span class="k">&amp;key</span> <span class="nv">data</span> <span class="k">&amp;allow-other-keys</span><span class="p">)</span>
              <span class="p">(</span><span class="nv">message</span> <span class="s">&quot;I sent: %S&quot;</span> <span class="p">(</span><span class="nv">assoc-default</span> <span class="ss">&#39;json</span> <span class="nv">data</span><span class="p">)))))</span>
 </pre></div>
 </div>

--- a/manual.html
+++ b/manual.html
@@ -129,8 +129,8 @@ arguments (i.e., it&#8217;s better to use <tt class="xref el el-symbol docutils 
 <colgroup><col class="label" /><col /></colgroup>
 <tbody valign="top">
 <tr><td class="label"><a class="fn-backref" href="#id1">[1]</a></td><td><tt class="xref el el-symbol docutils literal"><span class="pre">&amp;allow-other-keys</span></tt> is a special &#8220;markers&#8221; available in macros
-in the CL library for function definition such as <tt class="xref el el-symbol docutils literal"><span class="pre">defun*</span></tt> and
-<tt class="xref el el-symbol docutils literal"><span class="pre">function*</span></tt>.  Without this marker, you need to specify all arguments
+in the CL library for function definition such as <tt class="xref el el-symbol docutils literal"><span class="pre">cl-defun</span></tt> and
+<tt class="xref el el-symbol docutils literal"><span class="pre">cl-function</span></tt>.  Without this marker, you need to specify all arguments
 to be passed.  This becomes problem when request.el adds new arguments
 when calling callback functions.  If you use <tt class="xref el el-symbol docutils literal"><span class="pre">&amp;allow-other-keys</span></tt>
 (or manually ignore other arguments), your code is free from this


### PR DESCRIPTION
The cl-lib versions are aliases, but seem to be preferred these days. This also makes the github pages docs consistent with the readme.