### PR TITLE
Use Python 2 for tests if available

### DIFF
--- a/tests/request-testing.el
+++ b/tests/request-testing.el
@@ -94,7 +94,8 @@ The symbols other than `response' is bound using `cl-symbol-macrolet'."
   (interactive)
   (unless request-testing-server--port
     (let ((process (start-process "request-testing" " *request-testing*"
-                                  "python"
+				  (or (executable-find "python2")
+				      (executable-find "python"))
                                   (expand-file-name
                                    "testserver.py"
                                    request-testing-source-dir))))


### PR DESCRIPTION
Python 3 is the default on most system in these days. But testserver.py
is still uses deprecated Python 2 syntax (print as keyword).

Fixes this issue on Arch Linux:

```
  File "testserver.py", line 116
    print port
             ^
SyntaxError: Missing parentheses in call to 'print'. Did you mean print(port)?
```