### PR TITLE
Don't use tramp-make-tramp-file-name function

### DIFF
--- a/request.el
+++ b/request.el
@@ -966,14 +966,9 @@ Currently it is used only for testing.")
 (defun request--make-temp-file ()
   "Create a temporary file."
   (if (file-remote-p default-directory)
-      (let ((tramp-temp-name-prefix request-temp-prefix)
-            (vec (tramp-dissect-file-name default-directory)))
-        (tramp-make-tramp-file-name
-         (tramp-file-name-method vec)
-         (tramp-file-name-user vec)
-         (tramp-file-name-host vec)
-         (tramp-make-tramp-temp-file vec)
-         (tramp-file-name-hop vec)))
+      (let ((temporary-file-directory
+	     (tramp-get-remote-tmpdir (tramp-dissect-file-name default-directory))))
+	(make-temp-file request-temp-prefix))
     (make-temp-file request-temp-prefix)))
 
 (defun request--curl-normalize-files (files)
@@ -1025,15 +1020,7 @@ removed from the buffer before it is shown to the parser function.
   (let* (;; Use pipe instead of pty.  Otherwise, curl process hangs.
          (process-connection-type nil)
          ;; Avoid starting program in non-existing directory.
-         (home-directory (if (file-remote-p default-directory)
-                             (let ((vec (tramp-dissect-file-name default-directory)))
-                               (tramp-make-tramp-file-name
-                                (tramp-file-name-method vec)
-                                (tramp-file-name-user vec)
-                                (tramp-file-name-host vec)
-                                "~/"
-                                (tramp-file-name-hop vec)))
-                           "~/"))
+         (home-directory (or (file-remote-p default-directory) "~/"))
          (default-directory (expand-file-name home-directory))
          (buffer (generate-new-buffer " *request curl*"))
          (command (cl-destructuring-bind


### PR DESCRIPTION
Emacs 26 added two new required arguments to
tramp-make-tramp-file-name. Additionally, the method part of remote file
names is mandatory.

Also ensure request--make-temp-file creates temporary files in the
temporary folder on the remote host (instead of default-directory).