### PR TITLE
Fix reference to err variable

### DIFF
--- a/request.el
+++ b/request.el
@@ -123,7 +123,8 @@ See `request-log-level'."
 ;;; Utilities
 
 (defun request--safe-apply (function &rest arguments)
-  (condition-case err
+  "Apply FUNCTION with ARGUMENTS, suppressing any errors."
+  (condition-case nil
       (apply #'apply function arguments)
     ((debug error))))
 


### PR DESCRIPTION
I believe these variable names need to be switched -- as a side effect, this fixes at least one byte-compile warning:
```
request.el:125:1:Warning: Unused lexical variable ‘err’
```