### PR TITLE
Fix errors with using curl for file: URLs

### DIFF
--- a/request.el
+++ b/request.el
@@ -639,7 +639,7 @@ then kill the current buffer."
       (with-current-buffer buffer
         (request-log 'trace
           "(buffer-string) at %S =\n%s" buffer (buffer-string))
-        (when (/= (request-response-status-code response) 204)
+        (unless (equal (request-response-status-code response) 204)
           (goto-char (point-min))
           (setf (request-response-data response) (funcall parser)))))))
 
@@ -662,12 +662,17 @@ then kill the current buffer."
        (data (request-response-data response))
        (done-p (request-response-done-p response)))
 
-    ;; Parse response header
-    (request--clean-header response)
-    (request--cut-header response)
-    ;; Note: Try to do this even `error-thrown' is set.  For example,
-    ;; timeout error can occur while downloading response body and
-    ;; header is there in that case.
+    ;; Curl only adds a response header when using http: or https:.
+    (when (or (not (eq (request-response--backend response) 'curl))
+              (string-match-p "\\`https?:" (request-response-url response))
+              (not (string-match-p "\\`[[:alpha:]][-+.[:alnum:]]+://" (request-response-url response))))
+      ;; Parse response header
+      (request--clean-header response)
+      (request--cut-header response)
+      ;; Note: Try to do this even `error-thrown' is set.  For example,
+      ;; timeout error can occur while downloading response body and
+      ;; header is there in that case.
+      )
 
     ;; Parse response body
     (request-log 'debug "error-thrown = %S" error-thrown)
@@ -1143,7 +1148,7 @@ START-URL is the URL requested."
         (setf (request-response-url          response) url-effective)
         (setf (request-response-history      response) history)
         (setf (request-response-error-thrown response)
-              (or error (when (>= code 400) `(error . (http ,code)))))
+              (or error (when (and code (>= code 400)) `(error . (http ,code)))))
         (apply #'request--callback buffer settings))))))
 
 (cl-defun request--curl-sync (url &rest settings &key response &allow-other-keys)


### PR DESCRIPTION
Do not try to parse headers if the backend is curl and the URL does not have the "http" or "https" scheme, and tolerate a nil value for the response status code.  Curl does not print headers for "file:" or other non-HTTP URLs.

* `request.el` (`request--parse-data`): Use `equal`, which tolerates nil, to compare the response status code.
(`request--callback`): Do not try to parse headers if using curl and not using "http:" or "https:".
(`request--curl-callback`): Check whether the response status code is nil.

---

This change improves one common case but has one shortcoming.  If no scheme is specified, curl tries to guess the scheme, defaulting to HTTP, and curl's heuristic for guessing the scheme is not detailed in the manpage, so trying to replicate the heuristic would produce fragile logic.  Instead, I change `request--curl-callback` to assume that curl will default to HTTP.  This change should thus improve the common case of using a URL with an explicit, non-HTTP scheme, without breaking the cases of using a URL with an explicit HTTP scheme or using a URL without an explicit scheme where curl guesses HTTP; however, it does not address the case of using a URL without an explicit scheme where curl guesses a non-HTTP scheme (`request--curl-callback` will erroneously continue to try to parse headers in this case).