### PR TITLE
Synchronous deadlock second fix

### DIFF
--- a/request.el
+++ b/request.el
@@ -1181,11 +1181,9 @@ START-URL is the URL requested."
         (with-local-quit
           (cl-loop with iter = 0
                    until (or (>= iter 10) finished)
-                   if (request--process-live-p proc)
-                     do (accept-process-output proc 0.3)
-                   else
-                     do (cl-incf iter) and
-                     do (sleep-for 0 300)
+                   do (accept-process-output nil 0.3)
+                   unless (request--process-live-p proc)
+                     do (cl-incf iter)
                    end
                    finally (when (>= iter 10)
                              (request-log 'verbose


### PR DESCRIPTION
User louietan reports continued deadlock under `synch :t` whereby
[process.c](https://github.com/emacs-mirror/emacs/blob/96dd0196c28bc36779584e47fffcca433c9309cd/src/process.c#L5222) repeatedly detects a "ready" read filedescriptor, and consequently never calls
`status_notify()` to flush the semaphore.

It's unclear where the pending filedescriptor originates so we change the
call to `accept-process-output` to read all file descriptors rather than just the curl.

Attempt #132.