### PR TITLE
Kill inotify if `:sync t` hangs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,13 @@ env:
   - EVM_EMACS=emacs-25.2-travis
   - EVM_EMACS=emacs-25.3-travis
   - EVM_EMACS=emacs-26.1-travis
+  - EVM_EMACS=emacs-26.2-travis
   - EVM_EMACS=emacs-git-snapshot-travis
-allow_failures:
-  - EVM_EMACS=emacs-git-snapshot-travis
+
+matrix:
+  allow_failures:
+    - env: EVM_EMACS=emacs-git-snapshot-travis
+
 before_install:
   - pip install -q Flask==1.0.2 tornado==5.1.1
   - pip uninstall -y Werkzeug

--- a/README.rst
+++ b/README.rst
@@ -69,6 +69,8 @@ Block until completion:
              (lambda (&key response &allow-other-keys)
                (message "Done: %s" (request-response-status-code response)))))
 
+** BUGGY ** Under ``global-auto-revert-mode`` (a very common setting), the ``inotify`` mechanism sporadically impedes block-until-completion.  Upon detecting this condition, the request module deletes the inotify descriptor potentially deactivating auto-revert for the file buffer.
+
 Request binary data:
 
 .. code:: emacs-lisp

--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,8 @@ POST:
              (lambda (&key data &allow-other-keys)
                (message "I sent: %S" (assoc-default 'form data)))))
 
-Block until completion:
+| Block until completion:
+| **BUGGY** Under ``global-auto-revert-mode`` (a very common setting), the ``inotify`` mechanism sporadically impedes block-until-completion.  Upon detecting this condition, the request module deletes the inotify descriptor potentially cancelling auto-revert for the file buffer (auto-revert will restore the inotify in time).
 
 .. code:: emacs-lisp
 
@@ -68,8 +69,6 @@ Block until completion:
    :complete (cl-function
              (lambda (&key response &allow-other-keys)
                (message "Done: %s" (request-response-status-code response)))))
-
-** BUGGY ** Under ``global-auto-revert-mode`` (a very common setting), the ``inotify`` mechanism sporadically impedes block-until-completion.  Upon detecting this condition, the request module deletes the inotify descriptor potentially deactivating auto-revert for the file buffer.
 
 Request binary data:
 

--- a/request.el
+++ b/request.el
@@ -48,7 +48,7 @@
 (require 'cl-lib)
 (require 'url)
 (require 'mail-utils)
-(declare-function auto-revert-notify-rm-watch "autorevert")
+(require 'autorevert)
 
 (defgroup request nil
   "Compatible layer for URL request in Emacs."
@@ -1187,7 +1187,6 @@ START-URL is the URL requested."
                      do (cl-incf iter) and
                      if (>= iter 10)
                        do (let ((m "request--curl-sync: killing inotify"))
-                            (princ (format "%s\n" m) #'external-debugging-output)
                             (request-log 'warn m)
                             (auto-revert-notify-rm-watch))
                      end

--- a/request.el
+++ b/request.el
@@ -48,6 +48,7 @@
 (require 'cl-lib)
 (require 'url)
 (require 'mail-utils)
+(declare-function auto-revert-notify-rm-watch "autorevert")
 
 (defgroup request nil
   "Compatible layer for URL request in Emacs."

--- a/tests/request-testing.el
+++ b/tests/request-testing.el
@@ -29,6 +29,7 @@
 (require 'cl-lib)
 (require 'ert)
 (require 'request-deferred)
+(require 'autorevert)
 
 
 ;; Compatibility
@@ -39,6 +40,8 @@
 
 (unless (fboundp 'string-prefix-p)      ; not defined in Emacs 23.1
   (fset 'string-prefix-p (symbol-function 'request-testing-string-prefix-p)))
+
+(global-auto-revert-mode) ;; see github issue #132
 
 
 ;;;


### PR DESCRIPTION
Under auto-revert, should the inotify disallow
`wait_reading_process_output` (process.c in emacs source) from calling
status_notify() then kill it.

cf #132 