### PR TITLE
Rename unused arguments to start with underscore

### DIFF
--- a/tests/test-request.el
+++ b/tests/test-request.el
@@ -188,9 +188,9 @@ See also:
 (request-deftest request-get-sync-process-persists ()
   (request-testing-with-response-slots
    (cl-letf (((symbol-function 'request--curl-command)
-              (lambda (&rest args) (list "sleep" "1000")))
+              (lambda (&rest _) (list "sleep" "1000")))
              ((symbol-function 'url-retrieve-synchronously)
-              (lambda (&rest args) (sleep-for 1000))))
+              (lambda (&rest _) (sleep-for 1000))))
      (request (request-testing-url "report/some-path")
               :sync t :timeout 3 :parser 'json-read))
    (should done-p)


### PR DESCRIPTION
Otherwise, the byte compiler complains with errors like this:

```
In toplevel form:
third_party/elisp/request/tests/test-request.el:188:1:Error: Unused lexical argument `args'
```

You can tell the byte compiler the variable is unused by giving it a name starting with an underscore (`_`) ([manual](https://www.gnu.org/software/emacs/manual/html_node/elisp/Using-Lexical-Binding.html#Using-Lexical-Binding)).