### PR TITLE
Dynamically enable/disable --compressed curl option

### DIFF
--- a/request.el
+++ b/request.el
@@ -50,6 +50,7 @@
 (require 'mail-utils)
 (require 'autorevert)
 
+
 (defgroup request nil
   "Compatible layer for URL request in Emacs."
   :group 'comm
@@ -995,6 +996,10 @@ Currently it is used only for testing.")
                    (insert data)
                    (write-region (point-min) (point-max) tf nil 'silent))
                  (list name filename tf mime-type)))))))
+
+
+(declare-function tramp-get-remote-tmpdir "tramp")
+(declare-function tramp-dissect-file-name "tramp")
 
 (defun request--make-temp-file ()
   "Create a temporary file."


### PR DESCRIPTION
Shamelessly taking code from
https://github.com/skeeto/elfeed/commit/40d3463ca2c4380d2d9aaf79b0ad8583f464d81b to fix `request-curl` compression detection.

This also fix #111 