### PR TITLE
fix auto-revert-notify var name for emacs 27

### DIFF
--- a/request.el
+++ b/request.el
@@ -1195,8 +1195,8 @@ START-URL is the URL requested."
 (defun engdegard-auto-revert-notify-rm-watch ()
   "Disable file notification for current buffer's associated file."
   (let ((desc auto-revert-notify-watch-descriptor)
-        (table (if (boundp 'auto-revert--buffers-by-watch-descriptors)
-                   auto-revert--buffers-by-watch-descriptors
+        (table (if (boundp 'auto-revert--buffers-by-watch-descriptor)
+                   auto-revert--buffers-by-watch-descriptor
                  auto-revert-notify-watch-descriptor-hash-list)))
     (when desc
       (let ((buffers (delq (current-buffer) (gethash desc table))))

--- a/request.el
+++ b/request.el
@@ -1195,7 +1195,9 @@ START-URL is the URL requested."
 (defun engdegard-auto-revert-notify-rm-watch ()
   "Disable file notification for current buffer's associated file."
   (let ((desc auto-revert-notify-watch-descriptor)
-        (table auto-revert-notify-watch-descriptor-hash-list))
+        (table (if (boundp 'auto-revert--buffers-by-watch-descriptors)
+                   auto-revert--buffers-by-watch-descriptors
+                 auto-revert-notify-watch-descriptor-hash-list)))
     (when desc
       (let ((buffers (delq (current-buffer) (gethash desc table))))
         (if buffers


### PR DESCRIPTION
In Emacs 27, auto-revert-notify-watch-descriptor-hash-list has been
renamed to auto-revert--buffers-by-watch-descriptors. This small patch
averts an ancaught error.