### PR TITLE
Add fix for an edge case (with a test) involving "100 Continue" and long body

### DIFF
--- a/request.el
+++ b/request.el
@@ -394,7 +394,7 @@ Example::
                        (params nil)
                        (data nil)
                        (headers nil)
-                       (encoding 'utf-8)
+                       (encoding 'utf-8-unix)
                        (error nil)
                        (sync nil)
                        (response (make-request-response))
@@ -1171,6 +1171,9 @@ START-URL is the URL requested."
     (request-log 'debug "REQUEST--CURL-CALLBACK buffer = %S" buffer)
     (request-log 'debug "REQUEST--CURL-CALLBACK symbol-status = %S"
                  symbol-status)
+    (request-log 'debug "(buffer-string) =\n%s"
+                 (when (buffer-live-p buffer)
+                   (with-current-buffer buffer (buffer-string))))
     (cond
      ((and (memq (process-status proc) '(exit signal))
            (/= (process-exit-status proc) 0))

--- a/tests/test-request.el
+++ b/tests/test-request.el
@@ -358,6 +358,18 @@ See also:
                (filename . "data.csv")
                (name . "name"))))))
 
+(request-deftest request-post-files/expect-100-header-with-long-body ()
+                 :backends (curl)
+                 (request-testing-with-response-slots
+                  (request-testing-sync
+                   "longtextline"
+                   :type "GET"
+                   :parser 'buffer-string
+                   :headers '(("Expect" . "100-continue")))
+                  (should (equal status-code 200))
+                  (should (equal (length data) 18000))
+                  (should (string-prefix-p "111111" data))))
+
 
 ;;; PUT
 

--- a/tests/testserver.py
+++ b/tests/testserver.py
@@ -1,7 +1,7 @@
 import os
 
 from flask import (
-    Flask, request, session, redirect, abort, jsonify)
+    Flask, Response, request, session, redirect, abort, jsonify)
 from werkzeug.http import HTTP_STATUS_CODES
 
 app = Flask(__name__)
@@ -31,6 +31,10 @@ def page_report(path):
         json=request.json,
         username=session.get('username'),
     ))
+
+@app.route('/longtextline', methods=['GET'])
+def get_longline():
+    return Response('1'*18000, mimetype='text/plain')
 
 
 @app.route('/redirect/<path:path>', methods=all_methods)


### PR DESCRIPTION
Emacs 26.3, Ubuntu 18.04.1

Without that fix, Emacs interprets curl output as utf-8-dos and strips all \r .
It results in an error `(search-failed "^\r\n")`,
when moving from "100 Continue" to the next one in `request--goto-next-body`.

It's kind of strange behavior of Emacs,
since there is a single newline after the body:
```
body\n
(:num-redirects 0 :url-effective "http://127.0.0.1:60079/longtextline")
```
From the docs:

>Emacs recognizes which kind of end-of-line conversion to use based on the
contents of the file: if it sees only carriage returns, or only carriage return
followed by linefeed sequences, then it chooses the end-of-line conversion accordingly.

This behavior only manifests itself when body is a single long line.

Alternative solutions:
Use `inhibit-eol-conversion` somehow.
Change `(set-process-coding-system proc encoding encoding)` to 
`(set-process-coding-system proc 'no-conversion 'no-conversion)` in `request--curl`.

For reference I stumbled on this bug, while using ycmd (company-ycmd).
Original error was

```
REQUEST [error] Error (error) while connecting to http://127.0.0.1:34353/completions.
deferred error : (wrong-type-argument number-or-marker-p nil)
```
