### PR TITLE
Encoding is not decoding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,8 +56,7 @@ $(CASK_DIR): Cask
 
 .PHONY: compile
 compile: cask
-	! (cask eval "(let ((byte-compile-error-on-warn t)) (cask-cli/build))" 2>&1 | egrep -a "(Warning|Error):")
-	$(CASK) clean-elc
+	! ($(CASK) eval "(let ((byte-compile-error-on-warn t)) (cask-cli/build))" 2>&1 | egrep -a "(Warning|Error):") ; (ret=$$? ; $(CASK) clean-elc && exit $$ret)
 
 .PHONY: clean
 clean:
@@ -98,7 +97,7 @@ dist-clean:
 
 .PHONY: dist
 dist: dist-clean
-	cask package
+	$(CASK) package
 
 .PHONY: install
 install: compile dist

--- a/tests/testserver.py
+++ b/tests/testserver.py
@@ -34,7 +34,7 @@ def page_report(path):
 
 @app.route('/longtextline', methods=['GET'])
 def get_longline():
-    return Response('1'*18000, mimetype='text/plain')
+    return Response('.'*10000, mimetype='text/plain')
 
 @app.route('/redirect/<path:path>', methods=all_methods)
 def page_redirect(path):


### PR DESCRIPTION
Commit 1562f9c seems to conflate the desire to encode request data in
utf8 with also decoding server output.

In light of #157 and #158, I am removing utf-8 decoding altogether.

The impetus to encode to utf-8 in #77, #85, and
org-trello/org-trello#340 suggest nothing about also decoding in utf-8,
so I am crossing my fingers I won't rebreak for them.

Also, clean up logging.  It was impossible to follow with all the
capital letters.