### PR TITLE
Indent request like defun

### DIFF
--- a/request.el
+++ b/request.el
@@ -550,6 +550,7 @@ and requests.request_ (Python).
 .. _jQuery.ajax: http://api.jquery.com/jQuery.ajax/
 .. _requests.request: http://docs.python-requests.org
 "
+  (declare (indent defun))
   ;; FIXME: support CACHE argument (if possible)
   ;; (unless cache
   ;;   (setq url (request--url-no-cache url)))


### PR DESCRIPTION
Currently, `request` indented like below.

```emacs-lisp
(request
  url
  ...)

(request url
         ...)
```

But this patch merged, indented like below.

``` emacs-lisp
(request
  url
  ...)
  
(request url
  ...)
```

```