### PR TITLE
consume "HTTP/1.1 200 Tunnel established" status line.

### DIFF
--- a/request.el
+++ b/request.el
@@ -1096,7 +1096,7 @@ See \"set-cookie-av\" in http://www.ietf.org/rfc/rfc2965.txt")
 
 (defun request--consume-200-connection-established ()
   "Remove \"HTTP/* 200 Connection established\" header at the point."
-  (when (looking-at-p "HTTP/1\\.[0-1] 200 Connection established")
+  (when (looking-at-p "HTTP/1\\.[0-1] 200 \\(Connection\\|Tunnel\\) established")
     (delete-region (point) (progn (request--goto-next-body) (point)))))
 
 (defun request--curl-preprocess ()


### PR DESCRIPTION
[webpaste](https://github.com/etu/webpaste.el) uses `request` to send text to
paste server. But its gist support is currently broken by:

    1. not sending authorize tokens (not related to `request`);
    2. cannot get the right body data (the server returns a verbose 200
      status line)

This is the related log (truncated):

```
[debug] request--curl-callback: event finished
[trace] request--curl-callback: raw-bytes=
HTTP/1.1 200 Tunnel established^M
^M
HTTP/1.1 201 Created^M
Date: Wed, 27 Nov 2019 03:02:44 GMT^M
Content-Type: application/json; charset=utf-8^M
Content-Length: 3823^M
Server: GitHub.com^M
Status: 201 Created^M
^M
{
  (json response data)
}
```

This commit filters out that status line to in order to get the correct
response.