### PR TITLE
Adding decoding option for response

### DIFF
--- a/request.el
+++ b/request.el
@@ -1052,6 +1052,7 @@ removed from the buffer before it is shown to the parser function.
     (request-log 'debug "request--curl: %s" (mapconcat 'identity command " "))
     (setf (request-response--buffer response) buffer)
     (process-put proc :request-response response)
+    (set-process-coding-system proc 'no-conversion 'no-conversion)
     (set-process-query-on-exit-flag proc nil)
     (set-process-sentinel proc 'request--curl-callback)
     (when semaphore


### PR DESCRIPTION
#159 is broking #157. Getting `Got error: (search-failed "^\r\n")`

By removing the line `(set-process-coding-system proc encoding encoding)`  and change encoding back to `utf-8` from `utf-8-unix` , the carriage return will also automatically being removed by Emacs automatically encoding/decoding process. 
This make very long body request become broken, especially in Windows since its `default-process-coding-system` is set to `(utf-8-dos . utf-8-unix)`.

In the light of #158, it seems that most `request` dependent packages doesn't aware of that and do not properly decode the response output and assume that they will always receiving `utf-8` decoded data.
I think that we should add additional parameter `decoding` so we can separate `curl` output decoding from the global `default-process-coding-system`.