### PR TITLE
Fully deal with file URLs

### DIFF
--- a/request.el
+++ b/request.el
@@ -633,9 +633,9 @@ then send to PARSER."
 
 (defsubst request-url-file-p (url)
   "Return non-nil if URL looks like a file URL."
-  (when-let ((scheme (and (stringp url) (url-type (url-generic-parse-url url)))))
-    (and (stringp scheme)
-         (not (string-match-p "^http" scheme)))))
+  (if-let ((scheme (and (stringp url) (url-type (url-generic-parse-url url)))))
+      (and (stringp scheme)
+           (not (string-match-p "^http" scheme)))))
 
 (cl-defun request--callback (buffer
                              &key

--- a/request.el
+++ b/request.el
@@ -633,9 +633,9 @@ then send to PARSER."
 
 (defsubst request-url-file-p (url)
   "Return non-nil if URL looks like a file URL."
-  (if-let ((scheme (and (stringp url) (url-type (url-generic-parse-url url)))))
-      (and (stringp scheme)
-           (not (string-match-p "^http" scheme)))))
+  (let ((scheme (and (stringp url) (url-type (url-generic-parse-url url)))))
+    (and (stringp scheme)
+         (not (string-match-p "^http" scheme)))))
 
 (cl-defun request--callback (buffer
                              &key

--- a/request.el
+++ b/request.el
@@ -631,6 +631,12 @@ then send to PARSER."
           (setf (request-response-data response)
                 (if parser (funcall parser) (buffer-string))))))))
 
+(defsubst request-url-file-p (url)
+  "Return non-nil if URL looks like a file URL."
+  (when-let ((scheme (and (stringp url) (url-type (url-generic-parse-url url)))))
+    (and (stringp scheme)
+         (not (string-match-p "^http" scheme)))))
+
 (cl-defun request--callback (buffer
                              &key
                              parser success error complete
@@ -652,12 +658,8 @@ then send to PARSER."
        (data (request-response-data response))
        (done-p (request-response-done-p response)))
     (let* ((response-url (request-response-url response))
-           (scheme (and (stringp response-url)
-                        (url-type (url-generic-parse-url response-url))))
-           (curl-file-p (and (stringp scheme)
-                             (not (string-match-p "^http" scheme))
-                             (eq (request-response--backend response) 'curl))))
-      ;; curl does not add a header for say file:///foo/bar
+           (curl-file-p (and (eq (request-response--backend response) 'curl)
+                             (request-url-file-p response-url))))
       (unless curl-file-p
         (request--clean-header response)
         (request--cut-header response)))
@@ -901,15 +903,15 @@ Currently it is used only for testing.")
 (cl-defun request--curl-command
     (url &key type data headers response files* unix-socket encoding
          &allow-other-keys
-         &aux
-         (cookie-jar (convert-standard-filename
-                      (expand-file-name (request--curl-cookie-jar)))))
+         &aux (cookie-jar (convert-standard-filename
+                           (expand-file-name (request--curl-cookie-jar)))))
   "BUG: Simultaneous requests are a known cause of cookie-jar corruption."
   (append
-   (list request-curl "--silent" "--include"
-         "--location"
-         "--cookie" cookie-jar "--cookie-jar" cookie-jar
-         "--write-out" request--curl-write-out-template)
+   (list request-curl
+         "--silent" "--location"
+         "--cookie" cookie-jar "--cookie-jar" cookie-jar)
+   (unless (request-url-file-p url)
+     (list "--include" "--write-out" request--curl-write-out-template))
    request-curl-options
    (when (plist-get (request--curl-capabilities) :compression) (list "--compressed"))
    (when unix-socket (list "--unix-socket" unix-socket))
@@ -1057,11 +1059,12 @@ removed from the buffer before it is shown to the parser function.
     (process-put proc :request-response response)
     (set-process-coding-system proc 'no-conversion 'no-conversion)
     (set-process-query-on-exit-flag proc nil)
-    (set-process-sentinel proc 'request--curl-callback)
-    (when semaphore
-      (set-process-sentinel proc (lambda (&rest args)
-                                   (apply #'request--curl-callback args)
-                                   (apply semaphore args))))))
+    (let ((callback-2 (apply-partially #'request--curl-callback url)))
+      (if semaphore
+          (set-process-sentinel proc (lambda (&rest args)
+                                       (apply callback-2 args)
+                                       (apply semaphore args)))
+        (set-process-sentinel proc callback-2)))))
 
 (defun request--curl-read-and-delete-tail-info ()
   "Read a sexp at the end of buffer and remove it and preceding character.
@@ -1103,11 +1106,13 @@ See \"set-cookie-av\" in http://www.ietf.org/rfc/rfc2965.txt")
   (when (looking-at-p "HTTP/1\\.[0-1] 200 Connection established")
     (delete-region (point) (progn (request--goto-next-body) (point)))))
 
-(defun request--curl-preprocess ()
+(defun request--curl-preprocess (&optional url)
   "Pre-process current buffer before showing it to user."
   (let (history)
     (cl-destructuring-bind (&key num-redirects url-effective)
-        (request--curl-read-and-delete-tail-info)
+        (if (request-url-file-p url)
+            `(:num-redirects 0 :url-effective ,url)
+          (request--curl-read-and-delete-tail-info))
       (goto-char (point-min))
       (request--consume-100-continue)
       (request--consume-200-connection-established)
@@ -1150,7 +1155,7 @@ START-URL is the URL requested."
            for response in (cdr history)
            do (setf (request-response-url response) url)))
 
-(defun request--curl-callback (proc event)
+(defun request--curl-callback (url proc event)
   (let* ((buffer (process-buffer proc))
          (response (process-get proc :request-response))
          (settings (request-response-settings response)))
@@ -1167,7 +1172,7 @@ START-URL is the URL requested."
       (cl-destructuring-bind (&key code history error url-effective &allow-other-keys)
           (condition-case err
               (with-current-buffer buffer
-                (request--curl-preprocess))
+                (request--curl-preprocess url))
             ((debug error)
              (list :error err)))
         (request--curl-absolutify-location-history (plist-get settings :url)
@@ -1204,7 +1209,12 @@ START-URL is the URL requested."
                   settings)
       (let ((proc (get-buffer-process (request-response--buffer response))))
         (auto-revert-set-timer)
-        (when auto-revert-use-notify (request-auto-revert-notify-rm-watch))
+        (when auto-revert-use-notify
+          (if noninteractive
+              (dolist (buf (buffer-list))
+                (with-current-buffer buf
+                  (request-auto-revert-notify-rm-watch)))
+            (request-auto-revert-notify-rm-watch)))
         (with-local-quit
           (cl-loop with iter = 0
                    until (or (>= iter 10) finished)


### PR DESCRIPTION
Between curl 7.44 and 7.66, curl's behavior under --include changed.

Explicitly avoid --include with file URLs.

Closes #164