### PR TITLE
Revert #152

### DIFF
--- a/request.el
+++ b/request.el
@@ -1210,11 +1210,9 @@ START-URL is the URL requested."
       (let ((proc (get-buffer-process (request-response--buffer response))))
         (auto-revert-set-timer)
         (when auto-revert-use-notify
-          (if noninteractive
-              (dolist (buf (buffer-list))
-                (with-current-buffer buf
-                  (request-auto-revert-notify-rm-watch)))
-            (request-auto-revert-notify-rm-watch)))
+          (dolist (buf (buffer-list))
+            (with-current-buffer buf
+              (request-auto-revert-notify-rm-watch))))
         (with-local-quit
           (cl-loop with iter = 0
                    until (or (>= iter 10) finished)


### PR DESCRIPTION
inotify continues to lock emacs under global-auto-revert-mode.
Force kill inotify watchers under curl-sync (they will regenerate on their
own).