### PR TITLE
Support authentication with the curl backend

### DIFF
--- a/request.el
+++ b/request.el
@@ -912,30 +912,31 @@ password is found, the :type is used to construct the
 authentication type for curl (`--digest', `--basic', or the
 default `--anyauth') and the user and password are passed
 as the `--user' option."
-  (let ((type (concat "--" (or (plist-get auth :type) "anyauth")))
-        (user (plist-get auth :user))
-        (pass (plist-get auth :password)))
-    (cl-assert user t "At least a :user is required for :auth")
-    (cond
-     ((and user pass)
-      (list type "--user" (concat user ":" pass)))
-     (t
-      (let* ((urlobj (url-generic-parse-url url))
-             (host (url-host urlobj))
-             (port (url-port urlobj))
-             (cred (car (auth-source-search
-                         :host host :port port :user user :max 1))))
-        (cl-assert
-         cred t
-         (format "Failed to find credential for %s" user))
-        (cl-assert
-         (plist-get cred :secret) t
-         (format "Auth-source did not provide password for %s" user))
-        (let* ((secret (plist-get cred :secret))
-               (pass (if (functionp secret)
-                         (funcall secret)
-                       secret)))
-          (list type "--user" (concat user ":" pass))))))))
+  (if auth
+      (let ((type (concat "--" (or (plist-get auth :type) "anyauth")))
+            (user (plist-get auth :user))
+            (pass (plist-get auth :password)))
+        (cl-assert user t "At least a :user is required for :auth")
+        (cond
+         ((and user pass)
+          (list type "--user" (concat user ":" pass)))
+         (t
+          (let* ((urlobj (url-generic-parse-url url))
+                 (host (url-host urlobj))
+                 (port (url-port urlobj))
+                 (cred (car (auth-source-search
+                             :host host :port port :user user :max 1))))
+            (cl-assert
+             cred t
+             (format "Failed to find credential for %s" user))
+            (cl-assert
+             (plist-get cred :secret) t
+             (format "Auth-source did not provide password for %s" user))
+            (let* ((secret (plist-get cred :secret))
+                   (pass (if (functionp secret)
+                             (funcall secret)
+                           secret)))
+              (list type "--user" (concat user ":" pass)))))))))
 
 (cl-defun request--curl-command
     (url &key type data headers response files* unix-socket encoding auth

--- a/request.el
+++ b/request.el
@@ -1176,7 +1176,7 @@ See \"set-cookie-av\" in http://www.ietf.org/rfc/rfc2965.txt")
 START-URL is the URL requested."
   (cl-loop for prev-url = start-url then url
            for url in redirects
-           unless (string-match url-nonrelative-link url)
+           unless (and url (string-match url-nonrelative-link url))
            do (setq url (url-expand-file-name url prev-url))
            collect url))
 


### PR DESCRIPTION
Hello,

This relates to issue #32 from a while back. It adds support (in the curl backend only) for authentication with a new `:auth` key.

```
(request
 "https://example.com/path/"
 :auth '(:user "ndw" :password "sekrit" :type "digest")
 :complete (cl-function
           (lambda (&key response &allow-other-keys)
             (message "Done: %s" (request-response-status-code response)))))
```

If the password is not provided, attempt to find it with `auth-source`. If, for example, you have a `~/.authinfo` file that contains:

```
machine example.com login ndw port 443 password sekrit
```

Then the password can be elided from the request:

```
(request
 "https://example.com/path/"
 :auth '(:user "ndw")
 :complete (cl-function
           (lambda (&key response &allow-other-keys)
             (message "Done: %s" (request-response-status-code response)))))
```

The `:type` key can be left out as well because the default is `--anyauth`.

There is one thing I cannot work out: with the authentication arguments, `request--curl-absolutify-redirects` gets passed `(nil)` as its `redirects` and that causes an error. The second commit is an ugly hack that works around this problem, but a better solution would be to work out why `nil` gets passed in the first place.

The problem seems to be caused by the presence of the "USER:PASS" value that occurs after `--user`, but there are other options with values and I don't see any mapping to handle them.

Suggestions most welcome.