### PR TITLE
Auth digest

### DIFF
--- a/request.el
+++ b/request.el
@@ -912,30 +912,31 @@ password is found, the :type is used to construct the
 authentication type for curl (`--digest', `--basic', or the
 default `--anyauth') and the user and password are passed
 as the `--user' option."
-  (let ((type (concat "--" (or (plist-get auth :type) "anyauth")))
-        (user (plist-get auth :user))
-        (pass (plist-get auth :password)))
-    (cl-assert user t "At least a :user is required for :auth")
-    (cond
-     ((and user pass)
-      (list type "--user" (concat user ":" pass)))
-     (t
-      (let* ((urlobj (url-generic-parse-url url))
-             (host (url-host urlobj))
-             (port (url-port urlobj))
-             (cred (car (auth-source-search
-                         :host host :port port :user user :max 1))))
-        (cl-assert
-         cred t
-         (format "Failed to find credential for %s" user))
-        (cl-assert
-         (plist-get cred :secret) t
-         (format "Auth-source did not provide password for %s" user))
-        (let* ((secret (plist-get cred :secret))
-               (pass (if (functionp secret)
-                         (funcall secret)
-                       secret)))
-          (list type "--user" (concat user ":" pass))))))))
+  (if auth
+      (let ((type (concat "--" (or (plist-get auth :type) "anyauth")))
+            (user (plist-get auth :user))
+            (pass (plist-get auth :password)))
+        (cl-assert user t "At least a :user is required for :auth")
+        (cond
+         ((and user pass)
+          (list type "--user" (concat user ":" pass)))
+         (t
+          (let* ((urlobj (url-generic-parse-url url))
+                 (host (url-host urlobj))
+                 (port (url-port urlobj))
+                 (cred (car (auth-source-search
+                             :host host :port port :user user :max 1))))
+            (cl-assert
+             cred t
+             (format "Failed to find credential for %s" user))
+            (cl-assert
+             (plist-get cred :secret) t
+             (format "Auth-source did not provide password for %s" user))
+            (let* ((secret (plist-get cred :secret))
+                   (pass (if (functionp secret)
+                             (funcall secret)
+                           secret)))
+              (list type "--user" (concat user ":" pass)))))))))
 
 (cl-defun request--curl-command
     (url &key type data headers response files* unix-socket encoding auth

--- a/request.el
+++ b/request.el
@@ -1176,7 +1176,7 @@ See \"set-cookie-av\" in http://www.ietf.org/rfc/rfc2965.txt")
 START-URL is the URL requested."
   (cl-loop for prev-url = start-url then url
            for url in redirects
-           unless (string-match url-nonrelative-link url)
+           unless (and url (string-match url-nonrelative-link url))
            do (setq url (url-expand-file-name url prev-url))
            collect url))
 

--- a/tests/test-request.el
+++ b/tests/test-request.el
@@ -831,6 +831,19 @@ RESPONSE-BODY"))
       (let ((request--curl-capabilities-cache (make-hash-table :test 'eq :weakness 'key)))
         (should-not (funcall libz-f (funcall capabilities-f advice)))))))
 
+(request-deftest request-auth ()
+  :backends (curl)
+  (request-testing-with-response-slots
+      (cl-letf (((symbol-function 'auth-source-search)
+                 (lambda (&rest _args) '((:user "daniel" :secret (lambda () "secret")) nil))))
+        (let* ((request-log-level 'debug))
+          (request-testing-sync "report/some-path"
+                                :auth "digest")
+          (with-current-buffer request-log-buffer-name
+            (save-excursion
+              (search-backward "request--curl:")
+              (should (search-forward "--user elided" nil t))))))))
+
 (ert-deftest request-abort-killed-buffer ()
   (request-testing-with-response-slots
       (make-request-response

--- a/tests/test-request.el
+++ b/tests/test-request.el
@@ -836,12 +836,11 @@ RESPONSE-BODY"))
   (request-testing-with-response-slots
       (cl-letf (((symbol-function 'auth-source-search)
                  (lambda (&rest _args) '((:user "daniel" :secret (lambda () "secret")) nil))))
-        (let* ((request-log-level 'debug))
-          (request-testing-sync "report/some-path"
-                                :auth "digest")
+        (let ((request-log-level 'debug))
+          (request-testing-sync "report/some-path" :auth "digest")
           (with-current-buffer request-log-buffer-name
             (save-excursion
-              (search-backward "request--curl:")
+              (should (search-backward "request--curl:" nil t))
               (should (search-forward "--user elided" nil t))))))))
 
 (ert-deftest request-abort-killed-buffer ()


### PR DESCRIPTION
@ndw rather than keying off host and port, perhaps it'd be more natural just to key off host?

it'd also be nice to have emacs prompt the user if the auth entry is missing.
