### PR TITLE
testserver.py: redirect to correct path

### DIFF
--- a/tests/testserver.py
+++ b/tests/testserver.py
@@ -38,7 +38,7 @@ def get_longline():
 
 @app.route('/redirect/<path:path>', methods=all_methods)
 def page_redirect(path):
-    return redirect(path)
+    return redirect('/' + path)
 
 
 @app.route('/broken_redirect/<path:path>', methods=all_methods)


### PR DESCRIPTION
The /redirect handler on the test Flask server is meant to redirect
/redirect/foo/bar to /foo/bar, and the tests expect that behavior (for
example, request-get-simple-redirection assumes a chain of
/redirect/redirect/report/some-path -> /redirect/report/some-path ->
/report/some-path).

Instead, /redirect/foo/bar actually redirects to /redirect/foo/bar/foo/bar,
because the /redirect handler returns redirect(path), and Werkzeug's response
wrapper resolves non-absolute Location headers relative to the incoming
request's full URL.

This change prepends a "/" to the paramter to redirect(), casuing Werkzeug
to fix the Location header as intended, and fixing
request-get-simple-redirection.