### PR TITLE
remove spurious with-response-slots from request-auth test

### DIFF
--- a/tests/test-request.el
+++ b/tests/test-request.el
@@ -833,15 +833,14 @@ RESPONSE-BODY"))
 
 (request-deftest request-auth ()
   :backends (curl)
-  (request-testing-with-response-slots
-      (cl-letf (((symbol-function 'auth-source-search)
-                 (lambda (&rest _args) '((:user "daniel" :secret (lambda () "secret")) nil))))
-        (let ((request-log-level 'debug))
-          (request-testing-sync "report/some-path" :auth "digest")
-          (with-current-buffer request-log-buffer-name
-            (save-excursion
-              (should (search-backward "request--curl:" nil t))
-              (should (search-forward "--user elided" nil t))))))))
+  (cl-letf (((symbol-function 'auth-source-search)
+             (lambda (&rest _args) '((:user "daniel" :secret (lambda () "secret")) nil))))
+    (let ((request-log-level 'debug))
+      (request-testing-sync "report/some-path" :auth "digest")
+      (with-current-buffer request-log-buffer-name
+        (save-excursion
+          (should (search-backward "request--curl:" nil t))
+          (should (search-forward "--user elided" nil t)))))))
 
 (ert-deftest request-abort-killed-buffer ()
   (request-testing-with-response-slots


### PR DESCRIPTION
This test invokes request-testing-with-response-slots but has no body to
actually use the response slots; all the test assertions are in the
response-producing form.  Removing the macro invocation eliminates a
byte-compilation error.