### PR TITLE
fix a paren-matching error in request-testing-sync

### DIFF
--- a/tests/request-testing.el
+++ b/tests/request-testing.el
@@ -138,7 +138,7 @@ The symbols other than `response' is bound using `cl-symbol-macrolet'."
                 :catch
                 (lambda (x) (setq err x)))))))
     (cond (timeout (error "request-testing-sync: %s timed out" testing-url))
-          (err (error "request-testing-sync: %s %s") testing-url err)
+          (err (error "request-testing-sync: %s %s" testing-url err))
           (t result))))
 
 (defun request-testing-sort-alist (alist)


### PR DESCRIPTION
The error case in `request-testing-sync` was incorrectly parenthesized, which
would lead to the URL and error not actually being reported (and gives a
byte-compilation warning, which is how I found it).