### PR TITLE
Use url-retrieve silently

### DIFF
--- a/request.el
+++ b/request.el
@@ -779,7 +779,7 @@ associated process is exited."
          (url-request-method type)
          (url-request-data data)
          (buffer (url-retrieve url #'request--url-retrieve-callback
-                               (nconc (list :response response) settings)))
+                               (nconc (list :response response) settings) t))
          (proc (get-buffer-process buffer)))
     (request--install-timeout timeout response)
     (setf (request-response--buffer response) buffer)
@@ -834,8 +834,8 @@ associated process is exited."
                                 'timeout)
                           (setf (request-response-done-p response) t)
                           nil)
-                       (url-retrieve-synchronously url))
-                   (url-retrieve-synchronously url))))
+                       (url-retrieve-synchronously url t))
+                   (url-retrieve-synchronously url t))))
     (setf (request-response--buffer response) buffer)
     ;; It seems there is no way to get redirects and URL here...
     (when buffer


### PR DESCRIPTION
Hide those `Contacting host: localhost:8080` messages on every request, matching the behavior with the curl backend. I don't think there's a good reason to make this configurable.

If you're wondering why I'm using the `url-retrieve` backend at all, it seems synchronous curl is still quite slow as detailed in https://github.com/tkf/emacs-request/issues/5. In fact it seems to get 0.3 seconds added on to each request, and deleting the `0.3` from line 1244 does seem to make it run 300ms faster (though still not as fast as `url-retrieve`), though I didn't look to see if this would break anything outside my own use case.