### PR TITLE
Move definition of request-testing-server-name to top of file

### DIFF
--- a/tests/test-request.el
+++ b/tests/test-request.el
@@ -44,6 +44,14 @@
   (when (and no-capture (not (equal no-capture "")))
     (setq request-testing-capture-message nil)))
 
+(defvar request-testing-server-name
+  (let ((server (getenv "EL_REQUEST_TEST_SERVER")))
+    (if (member server '(nil "" "flask"))
+        "werkzeug"
+      server)))
+
+(message "Using test server: %s" request-testing-server-name)
+
 ;; Quick snippets for interactive testing:
 ;;   (setq request-backend 'curl)
 ;;   (setq request-backend 'url-retrieve)
@@ -595,14 +603,6 @@ based backends (e.g., `curl') should avoid this problem."
 
 
 ;;; Testing framework
-
-(defvar request-testing-server-name
-  (let ((server (getenv "EL_REQUEST_TEST_SERVER")))
-    (if (member server '(nil "" "flask"))
-        "werkzeug"
-      server)))
-
-(message "Using test server: %s" request-testing-server-name)
 
 (request-deftest request-tfw-server ()
   (let* ((response (request-testing-sync "report/some-path"))


### PR DESCRIPTION
This is to avoid a use-before-definition warning -- the variable was
referenced in a test earlier in the file than its definition.