### PR TITLE
fixes issue with missing mime-types

### DIFF
--- a/request.el
+++ b/request.el
@@ -911,8 +911,8 @@ BUG: Simultaneous requests are a known cause of cookie-jar corruption."
                                                "only one buffer or data entry permitted"))
                               (setq stdin-p t)))
                           (list name (or (plist-get (cdr item) :file) "-") (car item)
-                                (if (plist-get item :mime-type)
-                                    (format ";type=%s" (plist-get item :mime-type))
+                                (if (plist-get (cdr item) :mime-type)
+                                    (format ";type=%s" (plist-get (cdr item) :mime-type))
                                   "")))
                          (t (error (concat "request--curl-command-args: "
                                            "%S not string, buffer, or list")


### PR DESCRIPTION
Found an issue with request where it was ignoring the value of `:mime-type` when specified.

For example, this:

```emacs-lisp
(request-response-data
 (request "http://httpbin.org/post"
   :type "POST"
   :files `(("test" . ("file" :file "/home/ryan/hello.txt" :mime-type "text/plain")))
   :parser 'json-read
   :success (cl-function
             (lambda (&key data &allow-other-keys)
               (message "data %s" data)))))
```

would generate a `--form` flag like: `test=@/home/ryan/hello.txt;filename=file`. This patch fixes the code such that `type=...` is added.