### PR TITLE
Fix emacs native compilation warning

### DIFF
--- a/request.el
+++ b/request.el
@@ -814,12 +814,12 @@ Currently it is used only for testing.")
         (call-process request-curl nil t nil "--version")
         (let ((version
                (progn
-                 (setf (point) (point-min))
+                 (goto-char (point-min))
                  (when (re-search-forward "[.0-9]+" nil t)
                    (match-string 0))))
               (compression
                (progn
-                 (setf (point) (point-min))
+                 (goto-char (point-min))
                  (not (null (re-search-forward "libz\\>" nil t))))))
           (setf (gethash request-curl request--curl-capabilities-cache)
                 `(:version ,version :compression ,compression)))))))


### PR DESCRIPTION
To reproduce, have emacs built with native compilation and notice the compilation logs. You can then open the offending file and run `M-x emacs-lisp-native-compile-and-load` before and after the changes to see the warning is removed.

```
request.el:817:25: Warning: ‘point’ is an obsolete generalized variable; use
    ‘goto-char’ instead.
request.el:822:25: Warning: ‘point’ is an obsolete generalized variable; use
    ‘goto-char’ instead.
```