### PR TITLE
adds support for curl "<"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,11 +87,6 @@ jobs:
         cask link list
       continue-on-error: ${{ matrix.emacs_version == 'snapshot' }}
 
-    - name: test-install
-      if: startsWith(matrix.python_version, '2')
-      run: make test-install
-      continue-on-error: ${{ matrix.emacs_version == 'snapshot' }}
-
     - name: test
       if: startsWith(matrix.python_version, '2')
       run: make test

--- a/Makefile
+++ b/Makefile
@@ -139,4 +139,4 @@ test-install: test-install-vars
 	           (oset rcp :branch my-branch) \
 	           (oset rcp :commit my-commit))" \
 	--eval "(package-build--package rcp (package-build--checkout rcp))" \
-	--eval "(package-install-file (car (file-expand-wildcards (concat package-build-archive-dir \"request*.el\"))))" 2>&1 | egrep -ia "error: |fatal" && false)
+	--eval "(package-install-file (car (file-expand-wildcards (concat package-build-archive-dir \"request*.el\"))))" 2>&1 | egrep -ia "error: |fatal")

--- a/request.el
+++ b/request.el
@@ -913,7 +913,10 @@ BUG: Simultaneous requests are a known cause of cookie-jar corruption."
                                 (error (concat "request--curl-command-args: "
                                                "only one buffer or data entry permitted"))
                               (setq stdin-p t)))
-                          (list name (if (plist-get (cdr item) :use-contents) "<" "@") (or (plist-get (cdr item) :file) "-") (car item)
+                          (list name
+                                (if (plist-get (cdr item) :use-contents) "<" "@")
+                                (or (plist-get (cdr item) :file) "-")
+                                (car item)
                                 (if (plist-get (cdr item) :mime-type)
                                     (format ";type=%s" (plist-get (cdr item) :mime-type))
                                   "")))
@@ -947,9 +950,12 @@ posting fields, FILES containing one or more lists of the form
   (NAME . BUFFER)
   (NAME . (FILENAME :buffer BUFFER))
   (NAME . (FILENAME :data DATA))
+  (NAME . (FILENAME :data DATA :use-contents t))
 with NAME and FILENAME defined by curl(1)'s overwrought `--form` switch format,
 TIMEOUT in seconds, RESPONSE a mandatory struct, ENCODING, and SEMAPHORE,
-an internal semaphore.
+an internal semaphore.  Adding `:use-contents t` sends a text field
+with the file's contents as opposed to attaching a file as described
+in curl(1).
 
 Redirection handling strategy
 -----------------------------

--- a/request.el
+++ b/request.el
@@ -898,22 +898,22 @@ BUG: Simultaneous requests are a known cause of cookie-jar corruption."
             for (name . item) in files
             collect "--form"
             collect
-            (apply #'format "%s=@%s;filename=%s%s"
+            (apply #'format "%s=%s%s;filename=%s%s"
                    (cond ((stringp item)
-                          (list name item (file-name-nondirectory item) ""))
+                          (list name "@" item (file-name-nondirectory item) ""))
                          ((bufferp item)
                           (if stdin-p
                               (error (concat "request--curl-command-args: "
                                              "only one buffer or data entry permitted"))
                             (setq stdin-p t))
-                          (list name "-" (buffer-name item) ""))
+                          (list name "@" "-" (buffer-name item) ""))
                          ((listp item)
                           (unless (plist-get (cdr item) :file)
                             (if stdin-p
                                 (error (concat "request--curl-command-args: "
                                                "only one buffer or data entry permitted"))
                               (setq stdin-p t)))
-                          (list name (or (plist-get (cdr item) :file) "-") (car item)
+                          (list name (if (plist-get (cdr item) :use-contents) "<" "@") (or (plist-get (cdr item) :file) "-") (car item)
                                 (if (plist-get (cdr item) :mime-type)
                                     (format ";type=%s" (plist-get (cdr item) :mime-type))
                                   "")))


### PR DESCRIPTION
Okay so this is a very nuanced enhancement.

So `curl(1)`  says in the section about the `--form` flag:

> To force the 'content' part to be a file, prefix the file name with an @ sign. To just get the content part from a file, prefix the file name with the symbol <. The difference between @ and < is then that @ makes a file get attached in the post as a file upload, while the < makes a text field and just get the contents for that text field from a file.

Consider the difference between:

```bash
echo 'hello world' | curl https://httpbin.org/post -F "request=@-;" 
```

and

```bash
echo 'hello world' | curl https://httpbin.org/post -F "request=<-;" 
```

Before this PR, request by default sends all files using `@`. By specifying `:use-contents t` when uploading a file, it'll generate the curl `--form` argument to use `<` instead. So the roughly equivalent Emacs Lisp code would be:

```emacs lisp
(request "https://httpbin.org/post"
  :type "POST"
  :sync t
  :files '(("request" . ("request" :data "hello world" :use-contents t)))
  :parser 'buffer-string)
```

This has to be opted into specifically. The other `:files` forms default to using `@`.